### PR TITLE
Adjust to match upcoming Tagger API changes

### DIFF
--- a/src/js/lib/tagger-bridge.ts
+++ b/src/js/lib/tagger-bridge.ts
@@ -71,9 +71,9 @@ function collectRelationships(payload: TaggerPayload): RelationshipCollection {
     let link = `https://scryfall.com/search?q=${edge.foreignKey}=`;
 
     if (isTheRelatedTag) {
-      name = edge.contentName;
+      name = edge.subjectName;
       tagType = edge.classifier;
-      link += edge.contentId;
+      link += edge.subjectId;
     } else {
       name = edge.relatedName;
       tagType = edge.classifierInverse;

--- a/src/js/types/tagger.ts
+++ b/src/js/types/tagger.ts
@@ -11,8 +11,8 @@ export interface Relationship {
   classifierInverse: string;
   relatedName: string;
   classifier: string;
-  contentName: string;
-  contentId: string;
+  subjectName: string;
+  subjectId: string;
   relatedId: string;
   foreignKey: "illustrationId" | "oracleId";
   illustrationId?: string;
@@ -25,7 +25,7 @@ type TagEdge = {
     name: string;
     slug: string;
     type: "ILLUSTRATION_TAG" | "ORACLE_CARD_TAG" | "PRINTING_TAG";
-    namespace: "artwork" | "card" | "prints";
+    namespace: "artwork" | "card" | "print";
     __typename: "Tag";
   };
   __typename: "Tagging";
@@ -34,8 +34,8 @@ type TagEdge = {
 type RelationshipEdge = {
   classifier: string;
   classifierInverse: string;
-  contentId: string;
-  contentName: string;
+  subjectId: string;
+  subjectName: string;
   foreignKey: "illustrationId" | "oracleId";
   id: string;
   relatedId: string;

--- a/test/lib/tagger-bridge.test.ts
+++ b/test/lib/tagger-bridge.test.ts
@@ -45,7 +45,7 @@ describe("tagger bridge", () => {
               name: "Tag 3",
               type: "PRINTING_TAG",
               slug: "tag-3",
-              namespace: "prints",
+              namespace: "print",
               __typename: "Tag",
             },
           },
@@ -53,8 +53,8 @@ describe("tagger bridge", () => {
             id: "some-id",
             foreignKey: "illustrationId",
             relatedId: "related-id",
-            contentName: "Depicts Relationship",
-            contentId: "depicts-id",
+            subjectName: "Depicts Relationship",
+            subjectId: "depicts-id",
             relatedName: "Depicted Relationship",
             classifier: "DEPICTS",
             classifierInverse: "DEPICTED_IN",
@@ -64,8 +64,8 @@ describe("tagger bridge", () => {
             id: "some-id",
             foreignKey: "oracleId",
             relatedId: "related-id",
-            contentName: "Better Than Relationship",
-            contentId: "worse-than-id",
+            subjectName: "Better Than Relationship",
+            subjectId: "worse-than-id",
             relatedName: "Worse Than Relationship",
             classifier: "BETTER_THAN",
             classifierInverse: "WORSE_THAN",
@@ -157,15 +157,15 @@ describe("tagger bridge", () => {
       expect(tags.oracle.length).toBe(2);
     });
 
-    it("uses contentName and classifier when it is the related tag", async () => {
+    it("uses subjectName and classifier when it is the related tag", async () => {
       lookupResult.edges = [
         {
           id: "some-id",
           __typename: "Relationship",
           foreignKey: "oracleId",
           relatedId: "oracle-id",
-          contentName: "Content Name",
-          contentId: "better-than-id",
+          subjectName: "Content Name",
+          subjectId: "better-than-id",
           relatedName: "Related Name",
           classifier: "BETTER_THAN",
           classifierInverse: "WORSE_THAN",
@@ -187,8 +187,8 @@ describe("tagger bridge", () => {
           __typename: "Relationship",
           foreignKey: "oracleId",
           relatedId: "not-oracle-id",
-          contentName: "Content Name",
-          contentId: "better-than-id",
+          subjectName: "Content Name",
+          subjectId: "better-than-id",
           relatedName: "Related Name",
           classifier: "BETTER_THAN",
           classifierInverse: "WORSE_THAN",
@@ -209,8 +209,8 @@ describe("tagger bridge", () => {
         // @ts-ignore
         foreignKey: "unknown",
         relatedId: "not-oracle-id",
-        contentName: "Content Name",
-        contentId: "better-than-id",
+        subjectName: "Content Name",
+        subjectId: "better-than-id",
         relatedName: "Related Name",
         classifier: "BETTER_THAN",
         classifierInverse: "WORSE_THAN",


### PR DESCRIPTION
There's a new Tagger API adjustment in flight with https://github.com/scryfall/tagger/pull/434. This update deprecates the old `contentId` and `contentName` fields in favor of the formalized concepts of Scryfall Subjects – `subjectId` and `subjectName` are the new fields.

Note that the Tagger change has NOT MERGED YET!!! This is just getting the update ready for you. We'll coordinate releases once I've thoroughly vetted the Tagger update.

This is _probably_ the last Tagger API change based on its solidifying object model. I'm still up in the air about adjusting the name "classifier" on the Edge type, but we'll cross that bridge when we get there (that's the least wrong of the bad names used in Tagger that I'm presently fixing).